### PR TITLE
Allow for a threaded query of the project list.

### DIFF
--- a/examples/reference-gertty.yaml
+++ b/examples/reference-gertty.yaml
@@ -27,6 +27,13 @@ servers:
 # 'digest'. Defaults to 'digest' if not set or set to an unexpected
 # value.
 #    auth-type: digest
+# Whether or not to use multiple threads when querying for the initial
+# project list.  Some gerrit servers are unable to respond to requests for
+# paginated lists of all projects, and so a different querying strategy is
+# required.
+#    threaded_query: False
+# Number of threads to use in the threadpool if threaded_query is True.
+#    threadpool_size: 10
 # A location where Gertty should store its git repositories.  These
 # can be the same git repositories where you do your own work --
 # Gertty will not modify them unless you tell it to, and even then the

--- a/gertty/config.py
+++ b/gertty/config.py
@@ -50,6 +50,8 @@ class ConfigSchema(object):
               'log-file': str,
               'socket': str,
               'auth-type': str,
+              'threaded_query': bool,
+              'threadpool_size': int,
               }
 
     servers = [server]
@@ -163,6 +165,9 @@ class Config(object):
                     "not have permissions set to 0600.\n"
                     "Permissions are: {}".format(self.path, oct(mode)))
                 exit(1)
+
+        self.threaded_query = server.get('threaded_query', False)
+        self.threadpool_size = server.get('threadpool_size', 10)
         self.auth_type = server.get('auth-type', 'digest')
         auth_types = ['digest', 'basic']
         if self.auth_type not in auth_types:


### PR DESCRIPTION
Some gerrit servers have so many projects that they fall over when you
try to query for the full list (as well as when passing normal
pagination options to try and limit the response).

This approach, while unorthodox, works.  It is disabled by default, but
when enabled, it queries for all projects based on the first letter of
their name.  To make it snappier, it utilizes a thread pool while
iterating over the list of possible prefixes.
